### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Build, Lint & Test


### PR DESCRIPTION
Potential fix for [https://github.com/Morfo-si/novelist/security/code-scanning/1](https://github.com/Morfo-si/novelist/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/pr.yml` so the workflow no longer relies on repository/org defaults.  
Best minimal fix without changing functionality: define workflow-level permissions with `contents: read`, which is sufficient for the shown steps and recommended by CodeQL as a safe baseline.

**Where to change:**  
- File: `.github/workflows/pr.yml`  
- Add `permissions:` near the top level (after `on:` block and before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
