### PR TITLE
Resolve code scanning findings: writable-close, x/sys CVE, scorecard perms

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,11 @@ on:
     - cron: '0 8 * * 1'
   workflow_dispatch:
 
-permissions: read-all
+# Minimal default; the analysis job below grants itself exactly the scopes it
+# needs. A workflow-level read-all is broader than required and both SonarCloud
+# and Scorecard's own Token-Permissions check flag it.
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -22,8 +22,8 @@ const (
 // exist. It is a no-op when the file is present. A stat error that is not
 // "file does not exist" (for example a permission problem) is returned rather
 // than silently treated as absence.
-func EnsureFile(path string) error {
-	_, err := os.Stat(path)
+func EnsureFile(path string) (err error) {
+	_, err = os.Stat(path)
 	if err == nil {
 		return nil
 	}
@@ -37,7 +37,13 @@ func EnsureFile(path string) error {
 	if err != nil {
 		return fmt.Errorf("create %s: %w", path, err)
 	}
-	defer f.Close()
+	// Closing a writable file can surface a deferred write error (e.g. a failed
+	// flush to disk); report it, but never let it mask an earlier failure.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close %s: %w", path, cerr)
+		}
+	}()
 
 	if _, err := f.WriteString(Header); err != nil {
 		return fmt.Errorf("write header to %s: %w", path, err)
@@ -48,7 +54,7 @@ func EnsureFile(path string) error {
 // Append writes a timestamped entry containing story to path. It is a no-op
 // when story is empty, preserving the original "save nothing for empty input"
 // behavior.
-func Append(path, story string) error {
+func Append(path, story string) (err error) {
 	if story == "" {
 		return nil
 	}
@@ -59,7 +65,13 @@ func Append(path, story string) error {
 	if err != nil {
 		return fmt.Errorf("open %s: %w", path, err)
 	}
-	defer f.Close()
+	// Closing a writable file can surface a deferred write error (e.g. a failed
+	// flush to disk); report it, but never let it mask an earlier failure.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close %s: %w", path, cerr)
+		}
+	}()
 
 	entry := fmt.Sprintf("\n## %s\n\n%s\n", time.Now().Format(dateFormat), story)
 	if _, err := f.WriteString(entry); err != nil {


### PR DESCRIPTION
Resolves the open code scanning alerts on `main`.

## Changes
- **fix: handle writable-file close errors in storage** (`6db407b`) — `EnsureFile`/`Append` now surface a failing `Close()` on the journal file via a named return (without masking an earlier write/open error). Resolves the two CodeQL `go/unhandled-writable-file-close` alerts. A failing close on a written file can mean the final flush to disk didn't land, so silently dropping it risked reporting "saved" on an entry that wasn't fully persisted.
- **build: bump golang.org/x/sys to v0.47.0** (`e2147ee`) — clears `GO-2026-5024` (windows-only integer overflow, fixed in v0.44.0). Not reachable from Novelist's code, but it was the module flagged by Scorecard's Vulnerabilities check and govulncheck's require-graph note.
- **ci: tighten scorecard.yml default permissions to `contents: read`** (`09aab67`) — the analysis job declares its own scopes, so the workflow-level `read-all` was broader than needed. Clears SonarCloud S8234 and improves Scorecard's own Token-Permissions check.

## Not addressed (no in-repo code change)
- Scorecard *CII-Best-Practices* (low) — needs a bestpractices.dev badge registration.
- Scorecard *Code-Review* (high) — historical; improves as reviewed PRs land (this PR is a start).

`make check` is green locally (vet, golangci-lint, race tests, govulncheck — now fully clean with no require-graph note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)